### PR TITLE
[GAP-27] Generic Attestations on REST APIs

### DIFF
--- a/gaps/gap-27_generic_attestation_on_rest_api/gap-27_generic_attestation_on_rest_api.md
+++ b/gaps/gap-27_generic_attestation_on_rest_api/gap-27_generic_attestation_on_rest_api.md
@@ -1,0 +1,39 @@
+---
+gap: GAP-27
+title: Generic Attestation Mechanism for REST APIs
+description: Some Golem/Yagna REST API calls will require a proof of an "attestation" to be passed as credential to the API call.
+author: stranger80 (@stranger80)
+status: Draft
+type: Standard
+---
+
+This is the template to be used for new GAP submissions. Note this has been heavily inspired by Ethereum [EIP template](https://github.com/ethereum/EIPs/blob/master/eip-template.md).
+
+The GAP number will be assigned by an editor. A GAP summary document shall be submitted by opening a pull request with GAP-related files placed in `./gaps/gap-draft_title/` directory. To submit your GAP, please use an abbreviated title in the filename, `gap-draft_title.md`.
+
+## Abstract
+Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
+
+## Motivation
+The motivation section should describe the "why" of this GAP. What problem does it solve? What benefit does it provide to the Golem ecosystem? What use cases does this GAP address?
+
+## Specification
+The technical specification should describe the syntax and semantics of any new feature. 
+
+## Rationale
+The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work.
+
+## Backwards Compatibility
+All GAPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The GAP **must** explain how the author proposes to deal with these incompatibilities.
+
+## Test Cases
+Test cases are very useful in summarizing the scope and specifics of a GAP.  If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in `./gaps/gap-draft_title/` directory.
+
+## [Optional] Reference Implementation
+An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification.  If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `./gaps/gap-draft_title/`.
+
+## Security Considerations
+All GAPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. 
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Some Golem/Yagna REST API calls will require a proof of an "attestation" to be passed as credential to the API call, eg. a proof of a multi-sig on a resource Access Control List. 

This GAP proposes a generic standard to be used for any attestation-like credentials on Yagna REST APIs.