### PR TITLE
Change schema ids to point to github

### DIFF
--- a/gaps/gap-25_golem_certificates/examples/partner-certificate.json
+++ b/gaps/gap-25_golem_certificates/examples/partner-certificate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
   "certificate": {
     "validityPeriod": {
       "notBefore": "2023-01-01T00:00:00Z",
@@ -32,7 +32,7 @@
     },
     "value": "9fd5c9a8cae2ead564c240a8f7fbaf14a03d6e4b64fcd16612fe8aadf2269be993279385c69f5e27a918191eab74ac1d3ba329eba925ddb3399b2cadfb8ec80d",
     "signer": {
-      "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+      "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
       "certificate": {
         "validityPeriod": {
           "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-25_golem_certificates/examples/restricted-certificate.json
+++ b/gaps/gap-25_golem_certificates/examples/restricted-certificate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
   "certificate": {
     "validityPeriod": {
       "notBefore": "2023-01-01T00:00:00Z",
@@ -38,7 +38,7 @@
     },
     "value": "8e25857653288b21cc03e32b1073b3ab83a8165e0aca3fdc89bf2fd95618136e3457561e94dc205d56c1e690c6d377023596226a0ac0b01e89d0a27a8ef04103",
     "signer": {
-      "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+      "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
       "certificate": {
         "validityPeriod": {
           "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-25_golem_certificates/examples/root-certificate.json
+++ b/gaps/gap-25_golem_certificates/examples/root-certificate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
   "certificate": {
     "validityPeriod": {
       "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md
+++ b/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md
@@ -53,7 +53,7 @@ The purpose of the certificate is to allow creation of digital signatures by a v
 
 When a certificate is signed, all properties in the `certificate` object are included in the signature not only the required properties. This allows inclusion of extra information that inherits the same cryptographic integrity protection as the essential data.
 
-The schema file can be found in the `schemas/v1` folder and accessible at `https://golem.network/schemas/v1/certificate.schema.json`.
+The schema file can be found in the `schemas/v1` folder and accessible at `https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json`.
 
 ##### Subject
 
@@ -96,7 +96,7 @@ This object contains the details of the signature validating the subject and pro
 
 #### Permissions
 
-This schema defines the available permission control in the Golem network. It can be found in the `schemas/v1` folder or can be accessed at `https://golem.network/schemas/v1/permissions.schema.json`.
+This schema defines the available permission control in the Golem network. It can be found in the `schemas/v1` folder or can be accessed at `https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/permissions.schema.json`.
 
 Permissions have two forms:
 - the string `all` which means that the subject is permitted to use all capabilities (present and future) of the Golem network

--- a/gaps/gap-31_node_descriptor/examples/node-descriptor.json
+++ b/gaps/gap-31_node_descriptor/examples/node-descriptor.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/node-descriptor.schema.json",
+  "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/node-descriptor.schema.json",
   "nodeDescriptor": {
     "nodeId": "0x338e02f29b63155beec8253af7ad367dd44b40c6",
     "validityPeriod": {
@@ -21,7 +21,7 @@
     },
     "value": "73814ddd3786786010849519fc30edaeec0d20d1df63d9d171da05cdc2b8419580219feca183a1834bd1e8ad34e0b471b9a59ef64087b32b545748c0e40a1c0c",
     "signer": {
-      "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+      "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
       "certificate": {
         "validityPeriod": {
           "notBefore": "2023-01-01T00:00:00Z",
@@ -54,7 +54,7 @@
         },
         "value": "74122f37e5f17a262afa535df8669e50ac810e49774f13574750ad9c9236da60adf26c81615331c531a9a39336adf7ca62d6909448b133394581bc4e4cefc700",
         "signer": {
-          "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+          "$schema": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
           "certificate": {
             "validityPeriod": {
               "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-31_node_descriptor/gap-31_node_descriptor.md
+++ b/gaps/gap-31_node_descriptor/gap-31_node_descriptor.md
@@ -30,7 +30,7 @@ This GAP introduces the key usage `signNode` for [Golem certificates](https://gi
 
 The schema heavily relies on references to previously defined items in [GAP-25](https://github.com/golemfactory/golem-architecture/blob/master/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md). When a node descriptor is signed, all data in the `nodeDescriptor` property are digitally signed to add cryptographic integrity protection. Similarly to the previously defined certificate schema, the node descriptor schema does not restrict additional properties allowing adding contextual information and allowing compatibility with future additions.
 
-The schema file can be found in the `schemas/v1` folder and accessible at `https://golem.network/schemas/v1/node-descriptor.schema.json`.
+The schema file can be found in the `schemas/v1` folder and accessible at `https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/node-descriptor.schema.json`.
 
 #### Node Id
 
@@ -38,7 +38,7 @@ The `nodeId` property contains the node's identifier on the network in hexadecim
 
 #### Permissions
 
-Details of how the node is permitted to use the Golem network. The content of this property is governed by the [permissions schema](https://golem.network/schemas/v1/permissions.schema.json).
+Details of how the node is permitted to use the Golem network. The content of this property is governed by the [permissions schema](https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/permissions.schema.json).
 
 #### Validity Period
 

--- a/schemas/v1/certificate.schema.json
+++ b/schemas/v1/certificate.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$id": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$id": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json",
   "title": "Golem Certificate structure",
-  "description": "Data describing an entity and its permissions within the Golem network",
+  "description": "Data describing an entity and its permissions within the Golem network. Schema described in detail in GAP-25.",
   "type": "object",
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "https://golem.network/schemas/v1/certificate.schema.json"
+      "const": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/certificate.schema.json"
     },
     "certificate": {
       "type": "object",

--- a/schemas/v1/node-descriptor.schema.json
+++ b/schemas/v1/node-descriptor.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$id": "https://golem.network/schemas/v1/node-descriptor.schema.json",
+  "$id": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/node-descriptor.schema.json",
   "title": "Golem Node descriptor with permissions",
-  "description": "Data representing a node within the Golem Network (Node ID) and the permissions granted to this node.",
+  "description": "Data representing a node within the Golem Network (Node ID) and the permissions granted to this node. Schema described in detail in GAP-31.",
   "type": "object",
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "https://golem.network/schemas/v1/node-descriptor.schema.json"
+      "const": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/node-descriptor.schema.json"
     },
     "nodeDescriptor": {
       "type": "object",

--- a/schemas/v1/permissions.schema.json
+++ b/schemas/v1/permissions.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$id": "https://golem.network/schemas/v1/permissions.schema.json",
+  "$id": "https://raw.githubusercontent.com/golemfactory/golem-architecture/master/schemas/v1/permissions.schema.json",
   "title": "Golem Network permissions",
-  "description": "Set of permissions related to features of the Golem Network",
+  "description": "Set of permissions related to features of the Golem Network. Schema described in detail in GAP-25.",
   "oneOf": [
     {
       "description": "The entity is granted permissions to use all capabilities available in the network",


### PR DESCRIPTION
Move GAP-25 and GAP-31 introduced JSON schemas into a common directory and change their IDs to point to GitHub.
(avoid having to upload these files to `golem.network` so there is only a _single source of truth_)

Examples have been updated.

The point of moving these to a single folder and leaving them under the GAP foldes is that:
- it is easier to find
- schemas can reference other schemas easier with relative reference