### PR TITLE
Finalize schema IDs

### DIFF
--- a/gaps/gap-25_golem_certificates/examples/partner-certificate.json
+++ b/gaps/gap-25_golem_certificates/examples/partner-certificate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
   "certificate": {
     "validityPeriod": {
       "notBefore": "2023-01-01T00:00:00Z",
@@ -32,7 +32,7 @@
     },
     "value": "9fd5c9a8cae2ead564c240a8f7fbaf14a03d6e4b64fcd16612fe8aadf2269be993279385c69f5e27a918191eab74ac1d3ba329eba925ddb3399b2cadfb8ec80d",
     "signer": {
-      "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+      "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
       "certificate": {
         "validityPeriod": {
           "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-25_golem_certificates/examples/restricted-certificate.json
+++ b/gaps/gap-25_golem_certificates/examples/restricted-certificate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
   "certificate": {
     "validityPeriod": {
       "notBefore": "2023-01-01T00:00:00Z",
@@ -38,7 +38,7 @@
     },
     "value": "8e25857653288b21cc03e32b1073b3ab83a8165e0aca3fdc89bf2fd95618136e3457561e94dc205d56c1e690c6d377023596226a0ac0b01e89d0a27a8ef04103",
     "signer": {
-      "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+      "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
       "certificate": {
         "validityPeriod": {
           "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-25_golem_certificates/examples/root-certificate.json
+++ b/gaps/gap-25_golem_certificates/examples/root-certificate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
   "certificate": {
     "validityPeriod": {
       "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md
+++ b/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md
@@ -107,6 +107,16 @@ Permissions have two forms:
         - `urls` property, which contains an array of URIs that the subject can access via the `outbound` feature. This list has the same semantics as `golem.srv.comp.manifest.net.inet.out.urls` property defined in [GAP-4 Computation Manifest](https://github.com/golemfactory/golem-architecture/blob/master/gaps/gap-4_comp_manifest/gap-4_comp_manifest.md#gcrs-golemsrvcompmanifest-namespace)
 
 
+### Schema ID and schema evolution
+
+The latest schema can always be found in the [architecture repository](https://github.com/golemfactory/golem-architecture) under the appropriate GAP that introduced the schema. We use the schema IDs leveraging the `golem.network` domain for easier access, but these URLs redirect to the github versions of the schema.
+The redirect always points to master branch to reference the latest, accepted version of the schema. When a schema is extended in a backward compatible way (for example: new optionals fields are added, new permissions defined) the schema will be updated under the same version of the API. If a schema modification is not backward compatible and results in new version of the schema, it would go to a new version folder and the schema ID changes to reflect that.
+
+Example:
+`https://schemas.golem.network/v1/certificate.schema.json` points to `https://raw.githubusercontent.com/golemfactory/golem-architecture/master/gaps/gap-25_golem_certificates/schemas/v1/certificate.schema.json` where the schema is published.
+If a backward compatible change would be done to the certificate it would still be accessible via the same URL, with the same schema ID under the `v1` version.
+When the schema evolves in a non backward compatible way it would have a new schema ID matching the new URL where it could be accessed: `https://schemas.golem.network/v2/certificate.schema.json`. This new URL would point to appropriate file on github or other service that hosts the published, accepted version of the schema.
+
 ### Signature creation and verification
 
 #### Serialization method

--- a/gaps/gap-25_golem_certificates/schemas/v1/certificate.schema.json
+++ b/gaps/gap-25_golem_certificates/schemas/v1/certificate.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$id": "https://golem.network/schemas/v1/certificate.schema.json",
+  "$id": "https://schemas.golem.network/v1/certificate.schema.json",
   "title": "Golem Certificate structure",
   "description": "Data describing an entity and its permissions within the Golem network",
   "type": "object",
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "https://golem.network/schemas/v1/certificate.schema.json"
+      "const": "https://schemas.golem.network/v1/certificate.schema.json"
     },
     "certificate": {
       "type": "object",

--- a/gaps/gap-25_golem_certificates/schemas/v1/permissions.schema.json
+++ b/gaps/gap-25_golem_certificates/schemas/v1/permissions.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
-  "$id": "https://golem.network/schemas/v1/permissions.schema.json",
+  "$id": "https://schemas.golem.network/v1/permissions.schema.json",
   "title": "Golem Network permissions",
   "description": "Set of permissions related to features of the Golem Network",
   "oneOf": [

--- a/gaps/gap-31_node_descriptor/examples/node-descriptor.json
+++ b/gaps/gap-31_node_descriptor/examples/node-descriptor.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://golem.network/schemas/v1/node-descriptor.schema.json",
+  "$schema": "https://schemas.golem.network/v1/node-descriptor.schema.json",
   "nodeDescriptor": {
     "nodeId": "0x338e02f29b63155beec8253af7ad367dd44b40c6",
     "validityPeriod": {
@@ -21,7 +21,7 @@
     },
     "value": "73814ddd3786786010849519fc30edaeec0d20d1df63d9d171da05cdc2b8419580219feca183a1834bd1e8ad34e0b471b9a59ef64087b32b545748c0e40a1c0c",
     "signer": {
-      "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+      "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
       "certificate": {
         "validityPeriod": {
           "notBefore": "2023-01-01T00:00:00Z",
@@ -54,7 +54,7 @@
         },
         "value": "74122f37e5f17a262afa535df8669e50ac810e49774f13574750ad9c9236da60adf26c81615331c531a9a39336adf7ca62d6909448b133394581bc4e4cefc700",
         "signer": {
-          "$schema": "https://golem.network/schemas/v1/certificate.schema.json",
+          "$schema": "https://schemas.golem.network/v1/certificate.schema.json",
           "certificate": {
             "validityPeriod": {
               "notBefore": "2000-01-01T00:00:00Z",

--- a/gaps/gap-31_node_descriptor/gap-31_node_descriptor.md
+++ b/gaps/gap-31_node_descriptor/gap-31_node_descriptor.md
@@ -48,6 +48,10 @@ The time period for which this node descriptor is valid. Semantics defined in th
 
 Semantics of the signature are defined in the [certificate schema](https://github.com/golemfactory/golem-architecture/blob/master/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md#signature) with one difference. A node descriptor cannot be used to create signatures so it cannot be self signed.
 
+### Schema ID and schema evolution
+
+The schema ID definition and schema evolution guideline is the same as for certificate schema found in [GAP-25]()
+
 ### Signature creation and verification
 
 The process is quite similar to what is described for [certificates](https://github.com/golemfactory/golem-architecture/blob/master/gaps/gap-25_golem_certificates/gap-25_golem_certificates.md#signature-creation-and-verification), but the signature is created for data in the `nodeDescriptor` property instead of the `certificate` one.

--- a/gaps/gap-31_node_descriptor/schemas/v1/node-descriptor.schema.json
+++ b/gaps/gap-31_node_descriptor/schemas/v1/node-descriptor.schema.json
@@ -15,7 +15,7 @@
         "nodeId": {
           "description": "The unique identifier of the node on the network",
           "type": "string",
-          "format": "^(0x)?[0-9a-fA-F]{40}$"
+          "format": "^0x[0-9a-fA-F]{40}$"
         },
         "permissions": {
           "description": "Permissions granted to the node",


### PR DESCRIPTION
Finalizing schema IDs to refer to the correct URLs.

also changed NodeId to require the `0x` prefix because ya-client-model::NodeId fails to deserialize when it is not present
fixed examples
related to https://github.com/golemfactory/golem-certificate/issues/19